### PR TITLE
Rewrite all routes to base URL in Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,2 @@
+{ "rewrites": [{ "source": "/(.*)", "destination": "/" }] }
+


### PR DESCRIPTION
This PR fixes the 404 when reloading on a subpage in the deployed Vercel app by configuring [rewrites](https://vercel.com/docs/project-configuration#project-configuration/rewrites) in `vercel.json`. All subpages will be rewritten to `/`.