### PR TITLE
Support backend rewrite

### DIFF
--- a/source/api.js
+++ b/source/api.js
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+const instance = axios.create({
+  baseURL: "https://points-api.illinoiswcs.org",
+  withCredentials: true,
+});
+
+instance.interceptors.response.use(undefined, function (err) {
+  if (err.response.status == 401) {
+    window.location.href = `${instance.defaults.baseURL}/auth/login`;
+  }
+
+  return Promise.reject(err);
+});
+
+export default instance;

--- a/source/pages/CheckIn/CheckIn.jsx
+++ b/source/pages/CheckIn/CheckIn.jsx
@@ -3,295 +3,62 @@ import { Tab, Dropdown, Input, Button, Message } from "semantic-ui-react";
 import Notifications, { notify } from "react-notify-toast";
 
 import "./checkIn.scss";
-import axios from "axios";
-
-const utils = require("../../utils");
+import axiosInstance from "../../api";
 
 const CheckIn = () => {
-  const [events, setEvents] = useState([]);
-  const [eventOptions, setEventOptions] = useState([]);
-  const [eventName, setEventName] = useState("");
-  const [eventId, setEventId] = useState("");
   const [eventKey, setEventKey] = useState("");
-  const [value, setValue] = useState("");
-  const [error, setError] = useState(false);
-
-  const [errorHeader, setErrorHeader] = useState("");
-  const [errorContent, setErrorContent] = useState("");
-  const [eventError, setEventError] = useState(false);
   const [eventKeyError, setEventKeyError] = useState(false);
-  const [netIdError, setNetIdError] = useState(false);
 
-  const handleSubmit = async (type) => {
-    if (type === "event") {
-      if (!value.match("^[A-Za-z0-9]*$")) {
-        setErrorHeader("Invalid Net ID");
-        setErrorContent("Net ID can only contain numbers and letters.");
-        return;
-      }
-      setErrorHeader("");
-      setErrorContent("");
-
-      const netIdError = value === "";
-      const eventKeyError = eventKey === "";
-      const eventError = eventId === "";
-
-      setNetIdError(netIdError);
-      setEventKeyError(eventKeyError);
-      setEventError(eventError);
-
-      if (netIdError || eventKeyError || eventError) {
-        return;
-      }
-
-      const res = await axios.put(
-        "https://points-api.illinoiswcs.org/api/events/" + eventId,
-        {
-          event_id: eventId,
-          netid: value.toLowerCase(),
-          event_key: eventKey,
-        }
-      );
-
-      if (res.data.code == 200) {
-        registerUser(value.toLowerCase(), eventKey);
-        notify.show("Successfully checked in!", "success");
-        setError(false);
-      } else if (res.data.code === 404) {
-        notify.show("Check in is unsuccessful", "error");
-        setError(true);
-      }
-    } else if (type == "officeHour" || type == "committee" || type == "gwc") {
-      await registerUser(value.toLowerCase(), eventKey);
-
-      if (error == "failed") {
-        notify.show("Check in is unsuccessful", "error");
-        setError(true);
-      } else {
-        notify.show("Successfully checked in!", "success");
-        setError(false);
-      }
+  const handleSubmit = async () => {
+    const eventKeyError = eventKey === "";
+    setEventKeyError(eventKeyError);
+    if (eventKeyError) {
+      return;
     }
+
+    axiosInstance
+      .patch("/profile", { eventKey: eventKey })
+      .then((res) => {
+        notify.show(res.data.message, "success");
+      })
+      .catch((err) => {
+        notify.show(err.response.data.message, "error");
+      });
   };
 
-  const handleEnterEvent = (tgt) => {
+  const handleEnter = (tgt) => {
     if (tgt.charCode === 13) {
-      handleSubmit("event");
+      handleSubmit();
     }
-  };
-
-  const handleEnterOH = (tgt) => {
-    if (tgt.charCode === 13) {
-      handleSubmit("office_hours");
-    }
-  };
-
-  const handleEnterGWC = (tgt) => {
-    if (tgt.charCode === 13) {
-      handleSubmit("gwc");
-    }
-  };
-
-  const handleChange = (event) => {
-    setValue(event.target.value);
   };
 
   const handleChangeKey = (event) => {
     setEventKey(event.target.value);
   };
 
-  const handleEventSelect = (e, data) => {
-    const eventId = data.value;
-    setEventId(eventId);
-    setEventName(data.text);
-  };
-
-  const ignoreInDropdown = (name) => {
-    var ignoreCase = name.toLowerCase();
-    return (
-      ignoreCase.includes("office hour") ||
-      ignoreCase.includes("open office") ||
-      ignoreCase.includes("girls who code")
-    );
-  };
-
-  const registerUser = async (netId, eventKey) => {
-    const response = await axios.put(
-      "https://points-api.illinoiswcs.org/api/users/" + netId,
-      { key: eventKey }
-    );
-
-    if (response.data.code == 200) {
-      setError(false);
-    } else {
-      setError("failed");
-    }
-  };
-
-  useEffect(() => {
-    axios
-      .get("https://points-api.illinoiswcs.org/api/events")
-      .then((response) => {
-        let events = response.data.result;
-
-        if (events) {
-          events = events.filter(function (e) {
-            return (
-              !e.name.toLowerCase().includes("office hour") &&
-              !e.name.toLowerCase().includes("open office") &&
-              !e.private
-            );
-          });
-          utils.sortEventsByNewest(events);
-          setEvents(events);
-        }
-      });
-  }, []);
-
-  useEffect(() => {
-    let newEventOptions = [];
-    events.forEach((event) => {
-      let eventOption = {};
-      if (!ignoreInDropdown(event.name)) {
-        eventOption.key = event._id;
-        eventOption.text = event.name;
-        eventOption.value = event._id;
-        newEventOptions.push(eventOption);
-      }
-    });
-    setEventOptions(newEventOptions);
-  }, [events]);
-
-  const panes = [
-    {
-      menuItem: "Event",
-      render: () => (
-        <Tab.Pane attached={false}>
-          <h4>Event</h4>
-
-          <Dropdown
-            button
-            className="icon"
-            floating
-            fluid
-            labeled
-            icon="calendar"
-            options={eventOptions}
-            onChange={handleEventSelect}
-            onKeyPress={handleEnterEvent}
-            search
-            value={eventId}
-            text={eventName}
-            default={"Select an Event"}
-            error={eventError}
-          />
-          <br />
-          <h4>NetId</h4>
-
-          <Input
-            fluid
-            error={netIdError}
-            placeholder="Enter your NetID ..."
-            value={value}
-            onChange={handleChange}
-            onKeyPress={handleEnterEvent}
-          />
-
-          <br />
-
-          <h4>Event Key</h4>
-
-          <Input
-            fluid
-            error={eventKeyError}
-            placeholder="Enter the event key..."
-            value={eventKey}
-            onChange={handleChangeKey}
-            onKeyPress={handleEnterEvent}
-          />
-
-          <br />
-          {error}
-
-          <Button fluid onClick={() => handleSubmit("event")}>
-            Check-in
-          </Button>
-
-          {(errorHeader !== "" || errorContent !== "") && (
-            <Message error header={errorHeader} content={errorContent} />
-          )}
-        </Tab.Pane>
-      ),
-    },
-    {
-      menuItem: "Open Office",
-      render: () => (
-        <Tab.Pane attached={false}>
-          <h4>NetId</h4>
-          <Input
-            fluid
-            placeholder="Enter your NetID ..."
-            value={value}
-            onChange={handleChange}
-            onKeyPress={handleEnterOH}
-          />
-          <br />
-          <h4>Key</h4>
-
-          <Input
-            fluid
-            placeholder="Enter the event key..."
-            value={eventKey}
-            onChange={handleChangeKey}
-            onKeyPress={handleEnterEvent}
-          />
-
-          <br />
-          <Button fluid onClick={() => handleSubmit("officeHour")}>
-            Check-in
-          </Button>
-        </Tab.Pane>
-      ),
-    },
-
-    {
-      menuItem: "Girls Who Code",
-      render: () => (
-        <Tab.Pane attached={false}>
-          <h4>NetId</h4>
-          <Input
-            fluid
-            placeholder="Enter your NetID ..."
-            value={value}
-            onChange={handleChange}
-            onKeyPress={handleEnterGWC}
-          />
-          <br />
-          <h4>Key</h4>
-
-          <Input
-            fluid
-            placeholder="Enter the event key..."
-            value={eventKey}
-            onChange={handleChangeKey}
-            onKeyPress={handleEnterEvent}
-          />
-
-          <br />
-          <Button fluid onClick={() => handleSubmit("gwc")}>
-            Check-in
-          </Button>
-        </Tab.Pane>
-      ),
-    },
-  ];
-
   return (
     <div className="check-in">
       <h1>Check-in</h1>
       <br />
       <Notifications />
-      <Tab menu={{ secondary: true, pointing: true }} panes={panes} />
+      <Tab.Pane>
+        <h4>Event Key</h4>
+
+        <Input
+          fluid
+          error={eventKeyError}
+          placeholder="Enter the event key..."
+          value={eventKey}
+          onChange={handleChangeKey}
+          onKeyPress={handleEnter}
+        />
+
+        <br />
+
+        <Button fluid onClick={() => handleSubmit()}>
+          Check-in
+        </Button>
+      </Tab.Pane>
     </div>
   );
 };

--- a/source/pages/CheckIn/CheckIn.jsx
+++ b/source/pages/CheckIn/CheckIn.jsx
@@ -9,6 +9,12 @@ const CheckIn = () => {
   const [eventKey, setEventKey] = useState("");
   const [eventKeyError, setEventKeyError] = useState(false);
 
+  useEffect(() => {
+    // Temporary patch to ensure users are authenticated before checking in
+    // TODO: Remove after implementing proper login flow
+    axiosInstance.get("/profile");
+  }, []);
+
   const handleSubmit = async () => {
     const eventKeyError = eventKey === "";
     setEventKeyError(eventKeyError);

--- a/source/pages/Events/Events.jsx
+++ b/source/pages/Events/Events.jsx
@@ -3,8 +3,8 @@ import { Segment, Button } from "semantic-ui-react";
 import "./events.scss";
 import EventModal from "./components/EventModal.jsx";
 import Notifications from "react-notify-toast";
-const utils = require("../../utils");
-const axios = require("axios");
+import axiosInstance from "../../api";
+import { getEventDate } from "../../utils";
 
 const Events = () => {
   const [events, setEvents] = useState([]);
@@ -12,26 +12,9 @@ const Events = () => {
   const [reloadOnClose, setReloadOnClose] = useState(false);
 
   useEffect(() => {
-    axios
-      .get("https://points-api.illinoiswcs.org/api/events")
-      .then(function (response) {
-        let events = response.data.result;
-
-        if (events) {
-          events = events.filter(function (e) {
-            return (
-              !e.name.toLowerCase().includes("office hour") &&
-              !e.name.toLowerCase().includes("open office") &&
-              !e.private
-            );
-          });
-          utils.sortEventsByNewest(events);
-          setEvents(events);
-        }
-      })
-      .catch(function (error) {
-        console.log(error);
-      });
+    axiosInstance.get("/events").then((res) => {
+      setEvents(res.data);
+    });
   }, []);
 
   const handleToggleModal = () => {
@@ -56,11 +39,11 @@ const Events = () => {
       <Button onClick={handleToggleModal}>Create New Event</Button>
       <Segment.Group>
         {events.map((event) => (
-          <Segment key={event._id} padded>
+          <Segment padded>
             <div className="flex">
               <div>
                 <h3>{event.name}</h3>
-                <h5 className="muted">{utils.getEventDate(event)}</h5>
+                <h5 className="muted">{getEventDate(event)}</h5>
               </div>
               <div></div>
             </div>

--- a/source/pages/Events/components/EventModal.jsx
+++ b/source/pages/Events/components/EventModal.jsx
@@ -8,8 +8,8 @@ import {
   Message,
   Checkbox,
 } from "semantic-ui-react";
-import axios from "axios";
 import "./eventModal.scss";
+import axiosInstance from "../../../api";
 
 const EventModal = ({ open, toggleModal, reloadOnClose }) => {
   const [name, setName] = useState("");
@@ -20,7 +20,6 @@ const EventModal = ({ open, toggleModal, reloadOnClose }) => {
   const [sameDay, setSameDay] = useState(false);
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
-  const [password, setPassword] = useState("");
   const [visibility, setVisibility] = useState("public");
 
   const [pointsErr, setPointsErr] = useState(false);
@@ -117,10 +116,6 @@ const EventModal = ({ open, toggleModal, reloadOnClose }) => {
     setEndTime(newEndTime);
   };
 
-  const handlePasswordChange = (_, data) => {
-    setPassword(data.value);
-  };
-
   const handleVisibilityChange = (_, data) => {
     setVisibility(data.value);
   };
@@ -157,15 +152,17 @@ const EventModal = ({ open, toggleModal, reloadOnClose }) => {
 
   const validateEvent = async () => {
     if (validateFields()) {
+      const start = new Date(`${startDate} ${startTime}`).getTime();
+      const end = new Date(
+        `${sameDay ? startDate : endDate} ${endTime}`
+      ).getTime();
+
       const event = {
         name: name,
         category: category,
         points: points,
-        startDate: startDate,
-        endDate: sameDay ? startDate : endDate,
-        startTime: startTime,
-        endTime: endTime,
-        password: password,
+        start: start,
+        end: end,
         private: visibility === "private",
       };
       await createEvent(event);
@@ -173,25 +170,20 @@ const EventModal = ({ open, toggleModal, reloadOnClose }) => {
   };
 
   const createEvent = async (event) => {
-    const res = await axios.post(
-      "https://points-api.illinoiswcs.org/api/events",
-      event
-    );
-    if (res.data.code === 200) {
-      setSuccess(true);
-      setError(false);
-      setMsg(`Success! Event key is ${res.data.result}.`), reloadOnClose();
-    } else if (res.data.code === 404) {
-      setSuccess(false);
-      setError(true);
-      setMsg("You are not authorized to create events.");
-    } else if (res.data.code === 500) {
-      setSuccess(false);
-      setError(true);
-      setMsg(
-        "Internal Error: event creation was unsuccessful. Please contact the current WCS infra chair for help."
-      );
-    }
+    axiosInstance
+      .post("/events", event)
+      .then((res) => {
+        setSuccess(true);
+        setError(false);
+        setMsg(`Success! Event key is ${res.data.key}.`), reloadOnClose();
+      })
+      .catch((err) => {
+        setSuccess(false);
+        setError(true);
+        setMsg(
+          "Internal Error: event creation was unsuccessful. Please contact the current WCS infra chair for help."
+        );
+      });
   };
 
   const categories = [
@@ -313,15 +305,6 @@ const EventModal = ({ open, toggleModal, reloadOnClose }) => {
             />
           </Form.Field>
 
-          <Form.Field
-            required
-            id="password"
-            control={Input}
-            label="NetId"
-            placeholder=""
-            onChange={handlePasswordChange}
-            value={password}
-          />
           <Message success content={msg} />
           <Message error content={msg} />
           <Button type="submit">Submit</Button>

--- a/source/pages/Events/components/EventModal.jsx
+++ b/source/pages/Events/components/EventModal.jsx
@@ -191,9 +191,8 @@ const EventModal = ({ open, toggleModal, reloadOnClose }) => {
     { key: "s", text: "Social", value: "social" },
     { key: "o", text: "Outreach", value: "outreach" },
     { key: "m", text: "Mentoring", value: "mentoring" },
-    { key: "t", text: "Explorations", value: "techTeam" },
+    { key: "t", text: "Explorations", value: "explorations" },
     { key: "g", text: "General Meeting", value: "generalMeeting" },
-    { key: "r", text: "Growth", value: "growth" },
     { key: "x", text: "Other", value: "other" },
   ];
 

--- a/source/utils.js
+++ b/source/utils.js
@@ -1,35 +1,14 @@
-const moment = require('moment')
+const getEventDate = (event) => {
+  const start = new Date(event.start).toLocaleDateString("en-US");
+  const end = new Date(event.end).toLocaleDateString("en-US");
 
-const sortEventsByNewest = events => {
-    events.sort(function(event1, event2) {
-            const date1 = moment(event1.startDate)
-            const date2 = moment(event2.startDate)
-
-            if (date1.isBefore(date2)) {
-                return 1;
-            }
-            if (date1.isAfter(date2)) {
-                return -1;
-            }
-
-            return 0;
-    });
-}
-
-const getEventDate = event => (
-    event.date ?
-        moment(event.date).format('MMM D YYYY')
-        : ( event.startDate === event.endDate ? 
-            moment(event.startDate).format('MMM D YYYY') 
-            : (
-                moment(event.startDate).format('MMM D YYYY') 
-                + ' - ' 
-                + moment(event.endDate).format('MMM D YYYY')
-            )
-        )
-)
+  if (start === end) {
+    return start;
+  } else {
+    return `${start} - ${end}`;
+  }
+};
 
 module.exports = {
-    sortEventsByNewest,
-    getEventDate,
-}
+  getEventDate,
+};


### PR DESCRIPTION
## Status:
:rocket: Ready

## Description

This PR is linked with IllinoisWCS/wcs-points-api#24 and should be merged after it is deployed.

Check in:
- NetID input, event selector, and event category menu panes are removed

Events:
- Categories are updated to match the backend
- Sorting logic is moved to the backend
- `getEventDate` is reimplemented with JavaScript `Date` objects

Points:
- Point value is singularized when a user has only one point

The current behavior is to authenticate the user when the check in and points page are visited. In the future, we could improve the UX by adding a login page. The `Create New Event` button should also be hidden to members.

Closes #55 

## Screenshots
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/34558138/213370212-c82dfba1-828e-4cb8-b61f-bd9ed10d6891.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/34558138/213370362-dd5900ff-ef14-4086-8d58-92f64e910886.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/34558138/213370478-5dd7b1f9-593c-40a2-8ec6-b4930ce5fc9c.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/34558138/213371071-c36f1f5d-7d99-49c5-8ce5-acaaf89f46f1.png">